### PR TITLE
Attempt to use delimited continuation to achieve separation of concern

### DIFF
--- a/Tiger-Compiler.cabal
+++ b/Tiger-Compiler.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.32.0.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: be8ebc97118727d83dd6bbfba23ab4d80abb163ab779dbeb8feef0e3e974e134
+-- hash: 86eac0d698fe3a7bfee31405f697064285b3d0f07dbb6fb25ed3777807c48884
 
 name:           Tiger-Compiler
 version:        0.1.0.0
@@ -135,6 +135,7 @@ test-suite compiler-test
       Tiger.ParserSpec
       Tiger.Semant.LevelSpec
       Tiger.Semant.MarkEscapeSpec
+      Tiger.Semant.TypeCheckSpec
       Tiger.SemantSpec
       Paths_Tiger_Compiler
   default-language: Haskell2010

--- a/Tiger-Compiler.cabal
+++ b/Tiger-Compiler.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.24
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 58c703cd7285ac255b1ded9e647379ef6cad6d7105bfcbabb7d845055f7f1107
+-- hash: be8ebc97118727d83dd6bbfba23ab4d80abb163ab779dbeb8feef0e3e974e134
 
 name:           Tiger-Compiler
 version:        0.1.0.0
@@ -49,6 +49,7 @@ library
     , mtl
     , rio
     , template-haskell
+    , transformers
   build-tools:
       alex
     , happy
@@ -75,6 +76,7 @@ library
       Tiger.Semant.Level
       Tiger.Semant.MarkEscape
       Tiger.Semant.Translate
+      Tiger.Semant.TypeCheck
       Tiger.Semant.Types
       Tiger.Syntax
       Unique
@@ -98,6 +100,7 @@ executable compiler-exe
     , monad-skeleton
     , mtl
     , rio
+    , transformers
   other-modules:
       Paths_Tiger_Compiler
   default-language: Haskell2010
@@ -120,6 +123,7 @@ test-suite compiler-test
     , monad-skeleton
     , mtl
     , rio
+    , transformers
   other-modules:
       FrameMock
       Linear.EvalSpec

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - mtl
 - monad-skeleton
 - rio
+- transformers
 
 default-extensions:
 - AllowAmbiguousTypes

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -3,6 +3,7 @@ module Tiger.Semant.TypeCheck where
 import           RIO
 import           Control.Monad.Trans.Cont
 import           Data.Extensible
+import           Tiger.Semant
 import           Tiger.Semant.Env
 import           Tiger.Semant.Types
 import qualified Tiger.LSyntax as T
@@ -10,39 +11,19 @@ import           SrcLoc
 import           Id
 
 
-data TranslateError =
-    UnknownType Id
-  | ExpectedIntType T.LExp Type
-  | ExpectedArray T.LValue Type
-data Result xs a = Done Type | Next a (Type -> Eff xs (Result xs a))
-
-lookupTypeIdEff :: (Lookup xs "typeEnv" (State TEnv), Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => LId -> Eff xs Type
-lookupTypeIdEff (L loc id) = lookupTypeId id >>= maybe (throwEff #translateError . L loc $ UnknownType id) pure
-skipName :: (
-    Lookup xs "typeEnv" (State TEnv)
-  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
-  ) => Type -> Eff xs Type
-skipName (TName lid) = lookupTypeIdEff lid >>= skipName
-skipName a@(TArray arr) = case arr ^. #range of
-  TName id -> do
-    ty <- skipName (TName id)
-    pure . TArray $ set #range ty arr
-  _ -> pure a
-skipName ty = pure ty
-checkInt :: (Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => Type -> T.LExp -> Eff xs ()
-checkInt ty e@(L loc _) =
-  unless (ty == TInt) . throwEff #translateError . L loc $ ExpectedIntType e ty
+data Result xs = Done Type | Next Hoge (Type -> Eff xs (Result xs))
+data Hoge = Value T.LValue | Exp T.LExp
 
 typeCheckValue :: (
     Lookup xs "typeEnv" (State TEnv)
   , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
-  ) => T.LValue -> ContT (Result xs T.LValue) (Eff xs) (Result xs T.LExp)
+  ) => T.LValue -> ContT (Result xs) (Eff xs) (Result xs)
 typeCheckValue (L loc (T.ArrayIndex lv le)) = do
-  valueTy <- shiftT $ \k -> pure $ Next lv k
+  valueTy <- shiftT $ \k -> pure $ Next (Value lv) k
   lift (skipName valueTy) >>= \case
-    TArray a -> resetT $ do
-      indexTy <- shiftT $ \k -> pure $ Next le k
+    TArray a -> do
+      indexTy <- shiftT $ \k -> pure $ Next (Exp le) k
       lift $ checkInt indexTy le
       pure . Done $ a ^. #range
-    ty -> lift . throwEff #translateError . L loc $ ExpectedArray lv ty
+    ty -> lift . throwEff #translateError . L loc $ ExpectedArrayType lv ty
 

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -1,0 +1,48 @@
+module Tiger.Semant.TypeCheck where
+
+import           RIO
+import           Control.Monad.Trans.Cont
+import           Data.Extensible
+import           Tiger.Semant.Env
+import           Tiger.Semant.Types
+import qualified Tiger.LSyntax as T
+import           SrcLoc
+import           Id
+
+
+data TranslateError =
+    UnknownType Id
+  | ExpectedIntType T.LExp Type
+  | ExpectedArray T.LValue Type
+data Result xs a = Done Type | Next a (Type -> Eff xs (Result xs a))
+
+lookupTypeIdEff :: (Lookup xs "typeEnv" (State TEnv), Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => LId -> Eff xs Type
+lookupTypeIdEff (L loc id) = lookupTypeId id >>= maybe (throwEff #translateError . L loc $ UnknownType id) pure
+skipName :: (
+    Lookup xs "typeEnv" (State TEnv)
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => Type -> Eff xs Type
+skipName (TName lid) = lookupTypeIdEff lid >>= skipName
+skipName a@(TArray arr) = case arr ^. #range of
+  TName id -> do
+    ty <- skipName (TName id)
+    pure . TArray $ set #range ty arr
+  _ -> pure a
+skipName ty = pure ty
+checkInt :: (Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => Type -> T.LExp -> Eff xs ()
+checkInt ty e@(L loc _) =
+  unless (ty == TInt) . throwEff #translateError . L loc $ ExpectedIntType e ty
+
+typeCheckValue :: (
+    Lookup xs "typeEnv" (State TEnv)
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => T.LValue -> ContT (Result xs T.LValue) (Eff xs) (Result xs T.LExp)
+typeCheckValue (L loc (T.ArrayIndex lv le)) = do
+  valueTy <- shiftT $ \k -> pure $ Next lv k
+  lift (skipName valueTy) >>= \case
+    TArray a -> resetT $ do
+      indexTy <- shiftT $ \k -> pure $ Next le k
+      lift $ checkInt indexTy le
+      pure . Done $ a ^. #range
+    ty -> lift . throwEff #translateError . L loc $ ExpectedArray lv ty
+

--- a/test/Tiger/Semant/TypeCheckSpec.hs
+++ b/test/Tiger/Semant/TypeCheckSpec.hs
@@ -1,0 +1,58 @@
+module Tiger.Semant.TypeCheckSpec (spec) where
+
+import           Control.Monad.Trans.Cont
+import           Data.Extensible
+import           RIO
+import qualified RIO.List as List
+import qualified RIO.List.Partial as Partial
+import qualified RIO.Map as Map
+import           Test.Hspec
+
+import qualified Frame as F
+import           FrameMock
+import qualified IR
+import           SrcLoc
+import           TestUtils
+import           Unique
+
+import           Tiger.Semant
+import           Tiger.Semant.BreakPoint
+import           Tiger.Semant.Env
+import           Tiger.Semant.Exp
+import           Tiger.Semant.Level
+import           Tiger.Semant.Translate
+import           Tiger.Semant.TypeCheck
+import           Tiger.Semant.Types
+import qualified Tiger.LSyntax as T (valueToLValue)
+import qualified Tiger.Syntax as T
+
+
+spec :: Spec
+spec = describe "hoge" $
+  it "a[0]" $ do
+    let ast = T.valueToLValue $ T.ArrayIndex (T.Id "a") (T.Int 0)
+        result = runEff $ do
+          id <- getUniqueEff #id
+          let arrayTy = TArray $ #range @= TInt <: #id @= id <: nil
+          insertType "a" arrayTy
+          evalContT (typeCheckValue ast) >>= \case
+            Done _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "1"
+            Next (Exp _) _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "2"
+            Next (Value _) k -> k arrayTy >>= \case
+                Done ty -> throwEff #translateError . dummyRealLocated $ NotImplemented $ "3: " ++ show ty
+                Next (Value _) _ -> throwEff #translateError . dummyRealLocated $ NotImplemented $ "4"
+                Next (Exp _) k -> k TInt >>= \case
+                    Done ty -> pure ty
+                    _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "5"
+    case result of
+      Left (L _ e) -> expectationFailure $ show e
+      Right ty -> do
+        ty `shouldBe` TInt
+
+runEff :: Eff '[
+        ("typeEnv" >: State TEnv)
+      , ("id" >: UniqueEff)
+      , ("translateError" >: EitherEff (RealLocated TranslateError))
+      ] a
+  -> Either (RealLocated TranslateError) a
+runEff = leaveEff . runEitherEff @"translateError" . runUniqueEff @"id" . evalTEnvEff initTEnv


### PR DESCRIPTION
ref. #2 

## What I did
- first try to use delimited continuation
- separate type checking of array index from semantic analysis
- implement a test for type checking independently of translation

## Concern
- no flexibility of return value.
- a caller doesn't know either `Done` or `Next`  return from shift, even though it is deterministic.