### PR TITLE
Introduce Coroutine Type

### DIFF
--- a/Tiger-Compiler.cabal
+++ b/Tiger-Compiler.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.24
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 02c724c49bb556909f618f3df82297bcec9e47e048123bdd3dc10b411bb48f21
+-- hash: 029202ce58cab7400338c2224d5c7cb38777cee0453ed282effc85852595acce
 
 name:           Tiger-Compiler
 version:        0.1.0.0
@@ -36,7 +36,7 @@ custom-setup
 library
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds DeriveFunctor GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fno-warn-unticked-promoted-constructors -fno-warn-name-shadowing
   build-depends:
       array
@@ -89,7 +89,7 @@ executable compiler-exe
   main-is: Main.hs
   hs-source-dirs:
       app
-  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds DeriveFunctor GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Tiger-Compiler
@@ -111,7 +111,7 @@ test-suite compiler-test
   main-is: Spec.hs
   hs-source-dirs:
       test
-  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds DeriveFunctor GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Tiger-Compiler

--- a/Tiger-Compiler.cabal
+++ b/Tiger-Compiler.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.24
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8fd0d2b444d1d60e8755313c6f8df3572554f3cb7d7de76bd2d3bb6353e41f43
+-- hash: baa7ca753b520a47473341c4b16965c1e1e98e88ca63e851ca9c16e3a4306839
 
 name:           Tiger-Compiler
 version:        0.1.0.0
@@ -55,6 +55,7 @@ library
     , happy
   exposed-modules:
       AbstSyntax.TH
+      Coroutine
       Env
       Frame
       Id

--- a/Tiger-Compiler.cabal
+++ b/Tiger-Compiler.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.32.0.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 58c703cd7285ac255b1ded9e647379ef6cad6d7105bfcbabb7d845055f7f1107
+-- hash: 8fd0d2b444d1d60e8755313c6f8df3572554f3cb7d7de76bd2d3bb6353e41f43
 
 name:           Tiger-Compiler
 version:        0.1.0.0
@@ -36,7 +36,7 @@ custom-setup
 library
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fno-warn-unticked-promoted-constructors -fno-warn-name-shadowing
   build-depends:
       array
@@ -49,6 +49,7 @@ library
     , mtl
     , rio
     , template-haskell
+    , transformers
   build-tools:
       alex
     , happy
@@ -75,6 +76,7 @@ library
       Tiger.Semant.Level
       Tiger.Semant.MarkEscape
       Tiger.Semant.Translate
+      Tiger.Semant.TypeCheck
       Tiger.Semant.Types
       Tiger.Syntax
       Unique
@@ -86,7 +88,7 @@ executable compiler-exe
   main-is: Main.hs
   hs-source-dirs:
       app
-  default-extensions: AllowAmbiguousTypes ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Tiger-Compiler
@@ -98,6 +100,7 @@ executable compiler-exe
     , monad-skeleton
     , mtl
     , rio
+    , transformers
   other-modules:
       Paths_Tiger_Compiler
   default-language: Haskell2010
@@ -107,7 +110,7 @@ test-suite compiler-test
   main-is: Spec.hs
   hs-source-dirs:
       test
-  default-extensions: AllowAmbiguousTypes ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Tiger-Compiler
@@ -120,6 +123,7 @@ test-suite compiler-test
     , monad-skeleton
     , mtl
     , rio
+    , transformers
   other-modules:
       FrameMock
       Linear.EvalSpec
@@ -131,6 +135,7 @@ test-suite compiler-test
       Tiger.ParserSpec
       Tiger.Semant.LevelSpec
       Tiger.Semant.MarkEscapeSpec
+      Tiger.Semant.TypeCheckSpec
       Tiger.SemantSpec
       Paths_Tiger_Compiler
   default-language: Haskell2010

--- a/Tiger-Compiler.cabal
+++ b/Tiger-Compiler.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.24
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: baa7ca753b520a47473341c4b16965c1e1e98e88ca63e851ca9c16e3a4306839
+-- hash: 02c724c49bb556909f618f3df82297bcec9e47e048123bdd3dc10b411bb48f21
 
 name:           Tiger-Compiler
 version:        0.1.0.0
@@ -36,7 +36,7 @@ custom-setup
 library
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fno-warn-unticked-promoted-constructors -fno-warn-name-shadowing
   build-depends:
       array
@@ -89,7 +89,7 @@ executable compiler-exe
   main-is: Main.hs
   hs-source-dirs:
       app
-  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Tiger-Compiler
@@ -111,7 +111,7 @@ test-suite compiler-test
   main-is: Spec.hs
   hs-source-dirs:
       test
-  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions: AllowAmbiguousTypes BlockArguments ConstraintKinds DataKinds GADTs GeneralizedNewtypeDeriving FlexibleContexts FlexibleInstances LambdaCase MultiWayIf NoImplicitPrelude OverloadedLabels PolyKinds ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Tiger-Compiler

--- a/package.yaml
+++ b/package.yaml
@@ -36,9 +36,11 @@ dependencies:
 - mtl
 - monad-skeleton
 - rio
+- transformers
 
 default-extensions:
 - AllowAmbiguousTypes
+- BlockArguments
 - ConstraintKinds
 - DataKinds
 - GADTs

--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,7 @@ default-extensions:
 - FlexibleContexts
 - FlexibleInstances
 - LambdaCase
+- MultiWayIf
 - NoImplicitPrelude
 - OverloadedLabels
 - PolyKinds

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ default-extensions:
 - BlockArguments
 - ConstraintKinds
 - DataKinds
+- DeriveFunctor
 - GADTs
 - GeneralizedNewtypeDeriving
 - FlexibleContexts

--- a/src/Coroutine.hs
+++ b/src/Coroutine.hs
@@ -2,11 +2,11 @@ module Coroutine where
 
 import RIO
 
-type family Coroutine (m :: * -> *) (xs :: [*]) (r :: *) where
-  Coroutine m '[] r = m r
-  Coroutine m ((a, b) ': xs) r = m (a, b -> Coroutine m xs r)
+type family Coroutine (xs :: [*]) (m :: * -> *) (r :: *) where
+  Coroutine '[] m r = m r
+  Coroutine ((a, b) ': xs) m r = m (a, b -> Coroutine xs m r)
 
-yield :: forall xs m a b r. Monad m => a -> (b -> Coroutine m xs r) -> Coroutine m ((a, b) ': xs) r
+yield :: forall xs m a b r. Monad m => a -> (b -> Coroutine xs m r) -> Coroutine ((a, b) ': xs) m r
 yield value cont = pure (value, cont)
 {-# INLINE yield #-}
 

--- a/src/Coroutine.hs
+++ b/src/Coroutine.hs
@@ -9,4 +9,3 @@ type family Coroutine (xs :: [*]) (m :: * -> *) (r :: *) where
 yield :: forall xs m a b r. Monad m => a -> (b -> Coroutine xs m r) -> Coroutine ((a, b) ': xs) m r
 yield value cont = pure (value, cont)
 {-# INLINE yield #-}
-

--- a/src/Coroutine.hs
+++ b/src/Coroutine.hs
@@ -1,0 +1,12 @@
+module Coroutine where
+
+import RIO
+
+type family Coroutine (m :: * -> *) (xs :: [*]) (r :: *) where
+  Coroutine m '[] r = m r
+  Coroutine m ((a, b) ': xs) r = m (a, b -> Coroutine m xs r)
+
+yield :: forall xs m a b r. Monad m => a -> (b -> Coroutine m xs r) -> Coroutine m ((a, b) ': xs) r
+yield value cont = pure (value, cont)
+{-# INLINE yield #-}
+

--- a/src/SrcLoc.hs
+++ b/src/SrcLoc.hs
@@ -40,7 +40,7 @@ combineRealSrcSpan span1 span2 = RealSrcSpan file srow scol erow ecol
     (srow, scol) = min (srcSRow span1, srcSCol span1) (srcSRow span2, srcSCol span2)
     (erow, ecol) = min (srcERow span1, srcECol span1) (srcERow span2, srcECol span2)
 
-data RealLocated e = L RealSrcSpan e deriving (Eq)
+data RealLocated e = L RealSrcSpan e deriving (Eq, Functor)
 instance Show e => Show (RealLocated e) where
   show (L loc e) = locatedMessage loc $ show e
 

--- a/src/Tiger/Semant.hs
+++ b/src/Tiger/Semant.hs
@@ -189,12 +189,14 @@ translateArrayCreation (L loc (typeid, size, init)) = do
 
 translateWhileLoop :: HasTranslateEff xs f => T.LExp -> T.LExp -> Eff xs (Exp, Type)
 translateWhileLoop bool body = do
+  (bool, cont) <- typeCheckWhileLoop (bool, body)
   (boolExp, boolTy) <- translateExp bool
-  checkInt boolTy bool
+  (body, cont) <- cont boolTy
   withBreakPoint $ do
     (bodyExp, bodyTy) <- translateExp body
-    checkUnit bodyTy body
-    (, TUnit) <$> whileLoopExp boolExp bodyExp
+    ty <- cont bodyTy
+    (, ty) <$> whileLoopExp boolExp bodyExp
+
 
 translateForLoop :: HasTranslateEff xs f => RealLocated (LId, Bool, T.LExp, T.LExp, T.LExp) -> Eff xs (Exp, Type)
 translateForLoop (L _ (L _ id, escape, from, to, body)) = do

--- a/src/Tiger/Semant.hs
+++ b/src/Tiger/Semant.hs
@@ -213,7 +213,7 @@ translateForLoop (L _ (L _ id, escape, from, to, body)) = do
 
 translateBreak :: (Lookup xs "breakpoint" BreakPointEff, Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => RealSrcSpan -> Eff xs (Exp, Type)
 translateBreak loc = breakExp >>= \case
-  Just exp -> pure (exp, TUnit)
+  Just exp -> pure (exp, typeCheckBreak)
   Nothing -> throwEff #translateError $ L loc BreakOutsideLoop
 
 translateFunApply :: HasTranslateEff xs f => RealLocated (LId, [T.LExp]) -> Eff xs (Exp, Type)

--- a/src/Tiger/Semant.hs
+++ b/src/Tiger/Semant.hs
@@ -128,7 +128,6 @@ translateValue (L loc (T.ArrayIndex lv le)) = do
   ty <- cont indexTy
   pure . (, ty) $ valueArrayIndexExp @f varExp indexExp
 
-
 translateBinOp :: forall f xs. HasTranslateEff xs f => RealLocated (T.LOp', T.LExp, T.LExp) -> Eff xs (Exp, Type)
 translateBinOp (L loc (op, left, right)) = do
   (left, cont) <- typeCheckBinOp (L loc (op, left, right))
@@ -139,7 +138,6 @@ translateBinOp (L loc (op, left, right)) = do
   if leftTy /= TString
     then (, ty) <$> binOpExp op leftExp rightExp
     else (, ty) <$> stringOpExp @f op leftExp rightExp
-
 
 translateIfElse :: HasTranslateEff xs f => RealLocated (T.LExp, T.LExp, T.LExp) -> Eff xs (Exp, Type)
 translateIfElse (L loc (bool, then', else')) = do
@@ -152,7 +150,6 @@ translateIfElse (L loc (bool, then', else')) = do
   ty <- cont elseTy
   (, ty) <$> ifElseExp boolExp thenExp elseExp
 
-
 translateIfNoElse :: HasTranslateEff xs f => T.LExp -> T.LExp -> Eff xs (Exp, Type)
 translateIfNoElse bool then' = do
   (bool, cont) <- typeCheckIfNoElse (bool, then')
@@ -161,7 +158,6 @@ translateIfNoElse bool then' = do
   (thenExp, thenTy) <- translateExp then'
   ty <- cont thenTy
   (, ty) <$> ifNoElseExp boolExp thenExp
-
 
 translateRecordCreation :: forall f xs. HasTranslateEff xs f => RealLocated (LId, [T.LFieldAssign]) -> Eff xs (Exp, Type)
 translateRecordCreation (L loc (typeid, fields)) = do
@@ -176,7 +172,6 @@ translateRecordCreation (L loc (typeid, fields)) = do
     translateFieldAssign :: T.LFieldAssign -> Eff xs (Id, (Exp, Type))
     translateFieldAssign (L _ (T.FieldAssign (L _ id) e)) = (id,) <$> translateExp e
 
-
 translateArrayCreation :: forall f xs. HasTranslateEff xs f => RealLocated (LId, T.LExp, T.LExp) -> Eff xs (Exp, Type)
 translateArrayCreation (L loc (typeid, size, init)) = do
   (size, cont) <- typeCheckArrayCreation (L loc (typeid, size, init))
@@ -185,7 +180,6 @@ translateArrayCreation (L loc (typeid, size, init)) = do
   (initExp, initTy) <- translateExp init
   ty <- cont initTy
   (, ty) <$> arrayCreationExp @f sizeExp initExp
-
 
 translateWhileLoop :: HasTranslateEff xs f => T.LExp -> T.LExp -> Eff xs (Exp, Type)
 translateWhileLoop bool body = do
@@ -196,7 +190,6 @@ translateWhileLoop bool body = do
     (bodyExp, bodyTy) <- translateExp body
     ty <- cont bodyTy
     (, ty) <$> whileLoopExp boolExp bodyExp
-
 
 translateForLoop :: HasTranslateEff xs f => RealLocated (LId, Bool, T.LExp, T.LExp, T.LExp) -> Eff xs (Exp, Type)
 translateForLoop (L _ (L _ id, escape, from, to, body)) = do
@@ -346,7 +339,6 @@ translateDecsList = fmap mconcat . traverse translateDecs
       where
         extractLId (L _ (TypeDec r)) = r ^. #id
 
-
 checkSameNameDec :: Lookup xs "translateError" (EitherEff (RealLocated TranslateError)) => [LId] -> Eff xs ()
 checkSameNameDec ids = case runCheckSameNameDec ids of
   Right _ -> pure ()
@@ -372,7 +364,6 @@ checkInvalidRecType decs =
     graph = typeDecToNode <$> decs
     isCycle (CyclicSCC _) = True
     isCycle _ = False
-
 
 typingType :: (
     Lookup xs "typeEnv" (State TEnv)

--- a/src/Tiger/Semant/Env.hs
+++ b/src/Tiger/Semant/Env.hs
@@ -14,28 +14,48 @@ import           Tiger.Semant.Types
 
 
 newtype Access f = Access (Record '["level" >: Level f,"access" >: F.Access f])
-data Var f = Var (Record '["type" >: Type, "access" >: Access f])
-           | Fun (Record '["label" :> Label, "parent" >: Level f, "domains" :> [Type], "codomain" :> Type])
+data VarAccess f = VarAccess (Access f)
+                 | FunAccess (Record '["label" :> Label, "parent" >: Level f])
+data VarType = VarType Type
+             | FunType (Record '["domains" >: [Type], "codomain" >: Type])
 
 type TEnv = E.Env Type
-type VEnv f = E.Env (Var f)
-type HasEnv xs f = (Lookup xs "varEnv" (State (VEnv f)), Lookup xs "typeEnv" (State TEnv))
+type VAEnv f = E.Env (VarAccess f)
+type VTEnv = E.Env VarType
+type HasEnv xs f = (Lookup xs "varAccessEnv" (State (VAEnv f)), Lookup xs "varTypeEnv" (State VTEnv), Lookup xs "typeEnv" (State TEnv))
 evalTEnvEff :: TEnv -> Eff (("typeEnv" >: State TEnv) ': xs) a -> Eff xs a
 evalTEnvEff = flip (evalStateEff @"typeEnv")
-evalVEnvEff :: Eff (("varEnv" >: State (VEnv f)) ': xs) a -> Eff xs a
-evalVEnvEff = flip (evalStateEff @"varEnv") (E.fromList [])
-evalEnvEff :: TEnv -> Eff (("typeEnv" >: State TEnv) ': ("varEnv" >: State (VEnv f)) ': xs) a -> Eff xs a
-evalEnvEff typeEnv = evalVEnvEff . evalTEnvEff typeEnv
+evalVAEnvEff :: Eff (("varAccessEnv" >: State (VAEnv f)) ': xs) a -> Eff xs a
+evalVAEnvEff = flip (evalStateEff @"varAccessEnv") (E.fromList [])
+evalVTEnvEff :: Eff (("varTypeEnv" >: State VTEnv) ': xs) a -> Eff xs a
+evalVTEnvEff = flip (evalStateEff @"varTypeEnv") (E.fromList [])
+evalEnvEff :: TEnv -> Eff (("typeEnv" >: State TEnv) ': ("varTypeEnv" >: State VTEnv) ': ("varAccessEnv" >: State (VAEnv f)) ': xs) a -> Eff xs a
+evalEnvEff typeEnv = evalVAEnvEff . evalVTEnvEff . evalTEnvEff typeEnv
 
 lookupTypeId :: Lookup xs "typeEnv" (State TEnv) => Id -> Eff xs (Maybe Type)
 lookupTypeId id = getsEff #typeEnv $ E.lookup id
-lookupVarId :: Lookup xs "varEnv" (State (VEnv f)) => Id -> Eff xs (Maybe (Var f))
-lookupVarId id = getsEff #varEnv $ E.lookup id
+lookupVarAccess :: Lookup xs "varAccessEnv" (State (VAEnv f)) => Id -> Eff xs (Maybe (VarAccess f))
+lookupVarAccess id = getsEff #varAccessEnv $ E.lookup id
+lookupVarType :: Lookup xs "varTypeEnv" (State VTEnv) => Id -> Eff xs (Maybe VarType)
+lookupVarType id = getsEff #varTypeEnv $ E.lookup id
 insertType :: (Lookup xs "typeEnv" (State TEnv)) => Id -> Type -> Eff xs ()
 insertType id ty = modifyEff #typeEnv $ E.insert id ty
-insertVar :: (Lookup xs "varEnv" (State (VEnv f))) => Id -> Var f -> Eff xs ()
-insertVar id v = modifyEff #varEnv $ E.insert id v
+insertVarAccess :: (Lookup xs "varAccessEnv" (State (VAEnv f))) => Id -> VarAccess f -> Eff xs ()
+insertVarAccess id v = modifyEff #varAccessEnv $ E.insert id v
+insertVarType :: (Lookup xs "varTypeEnv" (State VTEnv)) => Id -> VarType -> Eff xs ()
+insertVarType id v = modifyEff #varTypeEnv $ E.insert id v
+
+beginTEnvScope :: (Lookup xs "typeEnv" (State TEnv)) => Eff xs ()
+beginTEnvScope = modifyEff #typeEnv E.beginScope
+beginVTEnvScope :: (Lookup xs "varTypeEnv" (State VTEnv)) => Eff xs ()
+beginVTEnvScope = modifyEff #varTypeEnv E.beginScope
+endTEnvScope :: (Lookup xs "typeEnv" (State TEnv)) => Eff xs ()
+endTEnvScope = modifyEff #typeEnv E.endScope
+endVTEnvScope :: (Lookup xs "varTypeEnv" (State VTEnv)) => Eff xs ()
+endVTEnvScope = modifyEff #varTypeEnv E.endScope
 withTEnvScope :: (Lookup xs "typeEnv" (State TEnv)) => Eff xs a -> Eff xs a
 withTEnvScope = E.withEnvScope #typeEnv
-withVEnvScope :: (Lookup xs "varEnv" (State (VEnv f))) => Eff xs a -> Eff xs a
-withVEnvScope = E.withEnvScope #varEnv
+withVAEnvScope :: (Lookup xs "varAccessEnv" (State (VAEnv f))) => Eff xs a -> Eff xs a
+withVAEnvScope = E.withEnvScope #varAccessEnv
+withVTEnvScope :: (Lookup xs "varTypeEnv" (State VTEnv)) => Eff xs a -> Eff xs a
+withVTEnvScope = E.withEnvScope #varTypeEnv

--- a/src/Tiger/Semant/Translate.hs
+++ b/src/Tiger/Semant/Translate.hs
@@ -257,6 +257,7 @@ varInitExp access e = flip assignExp e =<< valueIdExp access
 
 seqExp :: (Lookup xs "temp" UniqueEff, Lookup xs "label" UniqueEff) => [Exp] -> Eff xs Exp
 seqExp es = case List.splitAt (length es - 1) es of
+  ([], []) -> pure unitExp
   ([], [e]) -> pure e
   (es, [e]) -> do
     stms <- mapM unNx es

--- a/src/Tiger/Semant/Translate.hs
+++ b/src/Tiger/Semant/Translate.hs
@@ -371,24 +371,3 @@ letExp [] exp = exp
 letExp decs (Ex e) = Ex $ IR.ESeq (IR.seqStm $ fmap (\(Nx s) -> s) decs) e
 letExp decs (Nx s) = Nx $ IR.seqStm (((\(Nx s) -> s) <$> decs) ++ [s])
 letExp decs (Cx genstm) = Cx $ \t f -> IR.seqStm (((\(Nx s) -> s) <$> decs) ++ [genstm t f])
--- data VarEntry f = Var (Access f)
-
--- type VEnv f = E.Env (VarEntry f)
--- data TranslateError =
---     VariableUndefined Id
---   | VariableNotInScope Id
--- lookupVarAccess :: (
---     Lookup xs "varEnv" (State (VEnv f))
---   , Lookup xs "translateError"(EitherEff (RealLocated TranslateError))) => LId -> Eff xs (Access f)
--- lookupVarAccess (L loc id) =
---    getsEff #varEnv (E.lookup id) >>= \case
---     Nothing -> throwEff #translateError . L loc $ VariableUndefined id
---     Just (Var v) -> pure $ v ^. #access
-
--- transVar :: (Lookup xs "nestingLevel" (NestingLevelEff f), Lookup xs "varEnv" (State (VEnv f)), Lookup xs "translateError" (EitherEff (RealLocated TranslateError)), F.Frame f) => Access f -> Eff xs Exp
--- transVar a =
---   varExp a >>= \case
---     Just v -> pure v
---     Nothing -> throwEff #translateError . L loc $ VariableNotInScope (unLId lid)
--- transExp :: (Lookup xs "nestingLevel" (NestingLevelEff f), Lookup xs "varEnv" (State (VEnv f)), Lookup xs "translateError"(EitherEff (RealLocated TranslateError)),  F.Frame f) =>  T.LExp -> Eff xs Exp
--- transExp (L _ (T.Var v)) = transVar v

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -240,3 +240,6 @@ typeCheckForLoop (from, to, body) =
       yield @'[] body $ \bodyTy -> do
         checkUnit bodyTy body
         pure TUnit
+
+typeCheckBreak :: Type
+typeCheckBreak = TUnit

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -227,3 +227,16 @@ typeCheckWhileLoop (bool, body) =
     yield @'[] body $ \bodyTy -> do
       checkUnit bodyTy body
       pure TUnit
+
+-- TODO: separate varEnv into accessEnv and typeEnv
+typeCheckForLoop :: (
+    Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => (T.LExp, T.LExp, T.LExp) -> Coroutine '[(T.LExp, Type), (T.LExp, Type), (T.LExp, Type)] (Eff xs) Type
+typeCheckForLoop (from, to, body) =
+  yield @'[(T.LExp, Type), (T.LExp, Type)] from $ \fromTy -> do
+    checkInt fromTy from
+    yield @'[(T.LExp, Type)] to $ \toTy -> do
+      checkInt toTy to
+      yield @'[] body $ \bodyTy -> do
+        checkUnit bodyTy body
+        pure TUnit

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -106,7 +106,7 @@ checkUnit ty e@(L loc _) =
 typeCheckId :: (
     Lookup xs "varEnv" (State (VEnv f))
   , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
-  ) => LId -> Coroutine (Eff xs) '[] Type
+  ) => LId -> Coroutine '[] (Eff xs) Type
 typeCheckId lid@(L loc id) = lookupVarIdEff lid >>= \case
   Var r -> pure $ r ^. #type
   Fun _ -> throwEff #translateError . L loc $ ExpectedVariable id
@@ -114,7 +114,7 @@ typeCheckId lid@(L loc id) = lookupVarIdEff lid >>= \case
 typeCheckRecField :: (
     Lookup xs "typeEnv" (State TEnv)
   , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
-  ) => RealLocated (T.LValue, Id) -> Coroutine (Eff xs) '[(T.LValue, Type)] Type
+  ) => RealLocated (T.LValue, Id) -> Coroutine '[(T.LValue, Type)] (Eff xs) Type
 typeCheckRecField (L loc (lv, field)) = yield @'[] lv $
   skipName >=> \case
     valueTy@(TRecord r) -> case List.lookup field (r ^. #map) of
@@ -125,7 +125,7 @@ typeCheckRecField (L loc (lv, field)) = yield @'[] lv $
 typeCheckArrayIndex :: (
     Lookup xs "typeEnv" (State TEnv)
   , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
-  ) => RealLocated (T.LValue, T.LExp) -> Coroutine (Eff xs) '[(T.LValue, Type), (T.LExp, Type)] Type
+  ) => RealLocated (T.LValue, T.LExp) -> Coroutine '[(T.LValue, Type), (T.LExp, Type)] (Eff xs) Type
 typeCheckArrayIndex (L loc (lv, le)) = yield @'[(T.LExp, Type)] lv $
   skipName >=> \case
     TArray a -> yield @'[] le $ \indexTy -> do

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -217,3 +217,13 @@ typeCheckArrayCreation (L loc (typeid, size, init)) =
             then pure ty
             else throwEff #translateError . L loc $ ExpectedType init (a ^. #range) initTy
     ty -> throwEff #translateError . L loc $ ExpectedArrayType (L loc (T.Id typeid)) ty
+
+typeCheckWhileLoop :: (
+    Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => (T.LExp, T.LExp) -> Coroutine '[(T.LExp, Type), (T.LExp, Type)] (Eff xs) Type
+typeCheckWhileLoop (bool, body) =
+  yield @'[(T.LExp, Type)] bool $ \boolTy -> do
+    checkInt boolTy bool
+    yield @'[] body $ \bodyTy -> do
+      checkUnit bodyTy body
+      pure TUnit

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -7,18 +7,11 @@ import           Tiger.Semant
 import           Tiger.Semant.Env
 import           Tiger.Semant.Types
 import qualified Tiger.LSyntax as T
+import           Coroutine
 import           SrcLoc
 import           Unique
 import           Id
 
-
-type family Coroutine (m :: * -> *) (xs :: [*]) (r :: *) where
-  Coroutine m '[] r = m r
-  Coroutine m ((a, b) ': xs) r = m (a, b -> Coroutine m xs r)
-
-yield :: forall xs m a b r. Monad m => a -> (b -> Coroutine m xs r) -> Coroutine m ((a, b) ': xs) r
-yield value cont = pure (value, cont)
-{-# INLINE yield #-}
 
 typeCheckArrayIndex :: (
     Lookup xs "typeEnv" (State TEnv)

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -1,25 +1,134 @@
 module Tiger.Semant.TypeCheck where
 
-import           RIO
-import           Control.Monad.Trans.Cont
 import           Data.Extensible
-import           Tiger.Semant
-import           Tiger.Semant.Env
-import           Tiger.Semant.Types
-import qualified Tiger.LSyntax as T
+import           RIO
+import qualified RIO.List as List
+
 import           Coroutine
 import           SrcLoc
 import           Unique
 import           Id
 
+import           Tiger.Semant.Env
+import           Tiger.Semant.Types
+import qualified Tiger.LSyntax as T
+
+
+data TranslateError =
+  -- typing
+    VariableUndefined Id
+  | VariableMismatchedWithDeclaredType Id Type Type
+  | UnknownType Id
+  | ExpectedType T.LExp Type Type
+  | ExpectedTypes [T.LExp] [Type] [Type]
+  | ExpectedUnitType T.LExp Type
+  | ExpectedIntType T.LExp Type
+  | ExpectedRecordType T.LValue Type
+  | ExpectedArrayType T.LValue Type
+  | ExpectedVariable Id
+  | ExpectedExpression T.LExp
+  | ExpectedFunction Id
+  | ExpectedTypeForRecordField T.LExp Id Type Type
+  | MissingRecordField T.LValue Type Id
+  | MissingRecordFieldInConstruction T.LExp Type Id
+  | ExtraRecordFieldInConstruction T.LExp Type Id
+  | InvalidRecTypeDeclaration [RealLocated TypeDec]
+  | MultiDeclaredName [LId]
+  | NotDeterminedNilType
+
+  -- translate
+  | BreakOutsideLoop
+
+  | NotImplemented String
+instance Show TranslateError where
+  show (VariableUndefined id) = "undefined variable: " ++ show id
+  show (VariableMismatchedWithDeclaredType id ty ty') = concat ["Couldn't match type: expression doesn't match with declared type: id = ", show id, ", declared type: ", show ty, ", actual type: ", show ty']
+  show (UnknownType id) = "undefined type: " ++ show id
+  show (ExpectedType (L _ e) ty ty') = concat ["Couldn't mach type: ", show ty, " type expected: exp = ", show e, ", actual type = ", show ty']
+  show (ExpectedTypes es types types') = concat [
+    "Couldn't match types: ", show types, " exptected: exps = ", show es, ", actual types = ", show types']
+  show (ExpectedUnitType (L _ e) ty) = concat ["Couldn't match type: unit type expected: exp = ", show e, ", actual type: ", show ty]
+  show (ExpectedIntType (L _ e) ty) = concat ["Couldn't match type: int type expected: exp = ", show e, ", actual type: ", show ty]
+  show (ExpectedRecordType (L _ v) ty) = concat ["Couldn't match type: record type expected: value = ", show v, ", actual type: ", show ty]
+  show (ExpectedArrayType (L _ v) ty) = concat ["Couldn't match type: array type expected: value = ", show v, ", actual type: ", show ty]
+  show (ExpectedVariable id) = concat ["Expected Variable: value = ", show id]
+  show (ExpectedExpression (L _ e)) = concat ["Expected Expression: ", show e]
+  show (ExpectedFunction id) = concat ["Expected Function: id = ", show id]
+  show (ExpectedTypeForRecordField (L _ e) id ty ty') = concat ["Couldn't match type: ", show ty, " type expected at field ", show id, ": exp = ", show e, ", actual type: ", show ty']
+  show (MissingRecordField (L _ v) ty id) = concat ["Missing record field: value = ", show v, ", type = ", show ty, ", field = ", show id]
+  show (MissingRecordFieldInConstruction (L _ v) ty id) = concat ["Missing record field in construction: value = ", show v, ", type = ", show ty, ", field = ", show id]
+  show (ExtraRecordFieldInConstruction (L _ v) ty id) = concat ["Record does not have field ", show id, ": value = ", show v, ", type = ", show ty]
+  show (InvalidRecTypeDeclaration decs) = concat ["Found circle type declarations: decs = ", show decs]
+  show (MultiDeclaredName decs) = concat ["Same name types, vars or functions declared: decs = ", show decs]
+  show NotDeterminedNilType = concat ["Couldn't determine the type of nil"]
+
+  show BreakOutsideLoop = "break should be inside while or for loop"
+  show (NotImplemented msg) = "not implemented: " ++ msg
+
+newtype FunDec = FunDec (Record '["id" >: LId, "args" >: [T.LField], "rettype" >: Maybe LId, "body" >: T.LExp])
+newtype VarDec = VarDec (Record '["id" >: LId, "escape" >: Bool, "type" >: Maybe LId, "init" >: T.LExp])
+newtype TypeDec = TypeDec (Record '["id" >: LId, "type" >: T.LType]) deriving Show
+data Decs = FunDecs [RealLocated FunDec] | VarDecs [RealLocated VarDec] | TypeDecs [RealLocated TypeDec]
+
+lookupTypeIdEff :: (Lookup xs "typeEnv" (State TEnv), Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => LId -> Eff xs Type
+lookupTypeIdEff (L loc id) = lookupTypeId id >>= maybe (throwEff #translateError . L loc $ UnknownType id) pure
+lookupVarIdEff ::  (
+    Lookup xs "varEnv" (State (VEnv f))
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => LId -> Eff xs (Var f)
+lookupVarIdEff (L loc id) = lookupVarId id >>= maybe (throwEff #translateError . L loc $ VariableUndefined id) pure
+
+skipName :: (
+    Lookup xs "typeEnv" (State TEnv)
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => Type -> Eff xs Type
+skipName (TName lid) = lookupTypeIdEff lid >>= skipName
+skipName a@(TArray arr) = case arr ^. #range of
+  TName id -> do
+    ty <- skipName (TName id)
+    pure . TArray $ set #range ty arr
+  _ -> pure a
+skipName ty = pure ty
+lookupSkipName :: (
+    Lookup xs "typeEnv" (State TEnv)
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => LId -> Eff xs Type
+lookupSkipName = skipName <=< lookupTypeIdEff
+
+checkInt :: (Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => Type -> T.LExp -> Eff xs ()
+checkInt ty e@(L loc _) =
+  unless (ty == TInt) . throwEff #translateError . L loc $ ExpectedIntType e ty
+checkUnit :: (Lookup xs "translateError" (EitherEff (RealLocated TranslateError))) => Type -> T.LExp -> Eff xs ()
+checkUnit ty e@(L loc _) =
+    unless (ty == TUnit) . throwEff #translateError . L loc $ ExpectedUnitType e ty
+
+
+typeCheckId :: (
+    Lookup xs "varEnv" (State (VEnv f))
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => LId -> Coroutine (Eff xs) '[] Type
+typeCheckId lid@(L loc id) = lookupVarIdEff lid >>= \case
+  Var r -> pure $ r ^. #type
+  Fun _ -> throwEff #translateError . L loc $ ExpectedVariable id
+
+typeCheckRecField :: (
+    Lookup xs "typeEnv" (State TEnv)
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => RealLocated (T.LValue, Id) -> Coroutine (Eff xs) '[(T.LValue, Type)] Type
+typeCheckRecField (L loc (lv, field)) = yield @'[] lv $
+  skipName >=> \case
+    valueTy@(TRecord r) -> case List.lookup field (r ^. #map) of
+      Just ty -> pure ty
+      Nothing -> throwEff #translateError . L loc $ MissingRecordField lv valueTy field
+    valueTy -> throwEff #translateError . L loc $ ExpectedRecordType lv valueTy
 
 typeCheckArrayIndex :: (
     Lookup xs "typeEnv" (State TEnv)
   , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
   ) => RealLocated (T.LValue, T.LExp) -> Coroutine (Eff xs) '[(T.LValue, Type), (T.LExp, Type)] Type
-typeCheckArrayIndex (L loc (lv, le)) = yield @'[(T.LExp, Type)] lv \valueTy ->
-  skipName valueTy >>= \case
-    TArray a -> yield @'[] le \indexTy -> do
+typeCheckArrayIndex (L loc (lv, le)) = yield @'[(T.LExp, Type)] lv $
+  skipName >=> \case
+    TArray a -> yield @'[] le $ \indexTy -> do
       checkInt indexTy le
       pure $ a ^. #range
     ty -> throwEff #translateError . L loc $ ExpectedArrayType lv ty

--- a/src/Tiger/Semant/TypeCheck.hs
+++ b/src/Tiger/Semant/TypeCheck.hs
@@ -1,0 +1,32 @@
+module Tiger.Semant.TypeCheck where
+
+import           RIO
+import           Control.Monad.Trans.Cont
+import           Data.Extensible
+import           Tiger.Semant
+import           Tiger.Semant.Env
+import           Tiger.Semant.Types
+import qualified Tiger.LSyntax as T
+import           SrcLoc
+import           Unique
+import           Id
+
+
+type family Coroutine (m :: * -> *) (xs :: [*]) (r :: *) where
+  Coroutine m '[] r = m r
+  Coroutine m ((a, b) ': xs) r = m (a, b -> Coroutine m xs r)
+
+yield :: forall xs m a b r. Monad m => a -> (b -> Coroutine m xs r) -> Coroutine m ((a, b) ': xs) r
+yield value cont = pure (value, cont)
+{-# INLINE yield #-}
+
+typeCheckArrayIndex :: (
+    Lookup xs "typeEnv" (State TEnv)
+  , Lookup xs "translateError" (EitherEff (RealLocated TranslateError))
+  ) => RealLocated (T.LValue, T.LExp) -> Coroutine (Eff xs) '[(T.LValue, Type), (T.LExp, Type)] Type
+typeCheckArrayIndex (L loc (lv, le)) = yield @'[(T.LExp, Type)] lv \valueTy ->
+  skipName valueTy >>= \case
+    TArray a -> yield @'[] le \indexTy -> do
+      checkInt indexTy le
+      pure $ a ^. #range
+    ty -> throwEff #translateError . L loc $ ExpectedArrayType lv ty

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -5,67 +5,123 @@ import RIO
 
 import Unique
 
+import Tiger.Semant
+import Tiger.Semant.Translate
 import Tiger.Semant.TypeCheck
 
 
 fetchTwoLabel :: (Label, Label)
 fetchTwoLabel = leaveEff . runUniqueEff @"label" $ (,) <$> newLabel <*> newLabel
 
-isExpectedVariable :: TranslateError -> Bool
+isExpectedVariable :: TypeCheckError -> Bool
 isExpectedVariable ExpectedVariable{} = True
 isExpectedVariable _ = False
-isUndefinedVariable :: TranslateError -> Bool
-isUndefinedVariable VariableUndefined{} = True
+isUndefinedVariable :: TypeCheckError -> Bool
+isUndefinedVariable Tiger.Semant.TypeCheck.VariableUndefined{} = True
 isUndefinedVariable _ = False
-isUnknownType :: TranslateError -> Bool
+isUnknownType :: TypeCheckError -> Bool
 isUnknownType UnknownType{} = True
 isUnknownType _ = False
-isExpectedExpression :: TranslateError -> Bool
+isExpectedExpression :: TypeCheckError -> Bool
 isExpectedExpression ExpectedExpression{} = True
 isExpectedExpression _ = False
-isExpectedIntType :: TranslateError -> Bool
+isExpectedIntType :: TypeCheckError -> Bool
 isExpectedIntType ExpectedIntType{} = True
 isExpectedIntType _ = False
-isExpectedUnitType :: TranslateError -> Bool
+isExpectedUnitType :: TypeCheckError -> Bool
 isExpectedUnitType ExpectedUnitType{} = True
 isExpectedUnitType _ = False
-isExpectedArrayType :: TranslateError -> Bool
+isExpectedArrayType :: TypeCheckError -> Bool
 isExpectedArrayType ExpectedArrayType{} = True
 isExpectedArrayType _ = False
-isExpectedRecordType :: TranslateError -> Bool
+isExpectedRecordType :: TypeCheckError -> Bool
 isExpectedRecordType ExpectedRecordType{} = True
 isExpectedRecordType _ = False
-isExpectedType :: TranslateError -> Bool
+isExpectedType :: TypeCheckError -> Bool
 isExpectedType ExpectedType{} = True
 isExpectedType _ = False
-isExpectedTypes :: TranslateError -> Bool
+isExpectedTypes :: TypeCheckError -> Bool
 isExpectedTypes ExpectedTypes{} = True
 isExpectedTypes _ = False
-isExpectedFunction :: TranslateError -> Bool
+isExpectedFunction :: TypeCheckError -> Bool
 isExpectedFunction ExpectedFunction{} = True
 isExpectedFunction _ = False
-isExpectedTypeForRecordField :: TranslateError -> Bool
+isExpectedTypeForRecordField :: TypeCheckError -> Bool
 isExpectedTypeForRecordField ExpectedTypeForRecordField{} = True
 isExpectedTypeForRecordField _ = False
-isExtraRecordFieldInConstruction :: TranslateError -> Bool
+isExtraRecordFieldInConstruction :: TypeCheckError -> Bool
 isExtraRecordFieldInConstruction ExtraRecordFieldInConstruction{} = True
 isExtraRecordFieldInConstruction _ = False
-isMissingRecordFieldInConstruction :: TranslateError -> Bool
+isMissingRecordFieldInConstruction :: TypeCheckError -> Bool
 isMissingRecordFieldInConstruction MissingRecordFieldInConstruction{} = True
 isMissingRecordFieldInConstruction _ = False
-isMissingRecordField :: TranslateError -> Bool
+isMissingRecordField :: TypeCheckError -> Bool
 isMissingRecordField MissingRecordField{} = True
 isMissingRecordField _ = False
-isBreakOutsideLoop :: TranslateError -> Bool
-isBreakOutsideLoop BreakOutsideLoop = True
-isBreakOutsideLoop _ = False
-isNotDeterminedNilType :: TranslateError -> Bool
+isNotDeterminedNilType :: TypeCheckError -> Bool
 isNotDeterminedNilType NotDeterminedNilType = True
 isNotDeterminedNilType _ = False
-isInvalidRecTypeDeclaration :: TranslateError -> Bool
+isInvalidRecTypeDeclaration :: TypeCheckError -> Bool
 isInvalidRecTypeDeclaration InvalidRecTypeDeclaration{} = True
 isInvalidRecTypeDeclaration _ = False
-isMultiDeclaredName :: TranslateError -> Bool
+isMultiDeclaredName :: TypeCheckError -> Bool
 isMultiDeclaredName MultiDeclaredName{} = True
 isMultiDeclaredName _ = False
 
+
+isBreakOutsideLoop :: TranslateError -> Bool
+isBreakOutsideLoop BreakOutsideLoop = True
+isBreakOutsideLoop _ = False
+
+
+
+isTypeCheckErrorAnd :: (TypeCheckError -> Bool) -> SemantAnalysisError -> Bool
+isTypeCheckErrorAnd p (TypeCheckError e) = p e
+isTypeCheckErrorAnd _ _ = False
+
+isTypeCheckErrorAndExpectedVariable :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedVariable = isTypeCheckErrorAnd isExpectedVariable
+isTypeCheckErrorAndUndefinedVariable :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndUndefinedVariable = isTypeCheckErrorAnd isUndefinedVariable
+isTypeCheckErrorAndUnknownType :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndUnknownType = isTypeCheckErrorAnd isUnknownType
+isTypeCheckErrorAndExpectedExpression :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedExpression = isTypeCheckErrorAnd isExpectedExpression
+isTypeCheckErrorAndExpectedIntType :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedIntType = isTypeCheckErrorAnd isExpectedIntType
+isTypeCheckErrorAndExpectedUnitType :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedUnitType = isTypeCheckErrorAnd isExpectedUnitType
+isTypeCheckErrorAndExpectedArrayType :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedArrayType = isTypeCheckErrorAnd isExpectedArrayType
+isTypeCheckErrorAndExpectedRecordType :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedRecordType = isTypeCheckErrorAnd isExpectedRecordType
+isTypeCheckErrorAndExpectedType :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedType = isTypeCheckErrorAnd isExpectedType
+isTypeCheckErrorAndExpectedTypes :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedTypes = isTypeCheckErrorAnd isExpectedTypes
+isTypeCheckErrorAndExpectedFunction :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedFunction = isTypeCheckErrorAnd isExpectedFunction
+isTypeCheckErrorAndExpectedTypeForRecordField :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExpectedTypeForRecordField = isTypeCheckErrorAnd isExpectedTypeForRecordField
+isTypeCheckErrorAndExtraRecordFieldInConstruction :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndExtraRecordFieldInConstruction = isTypeCheckErrorAnd isExtraRecordFieldInConstruction
+isTypeCheckErrorAndMissingRecordFieldInConstruction :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndMissingRecordFieldInConstruction = isTypeCheckErrorAnd isMissingRecordFieldInConstruction
+isTypeCheckErrorAndMissingRecordField :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndMissingRecordField = isTypeCheckErrorAnd isMissingRecordField
+isTypeCheckErrorAndNotDeterminedNilType :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndNotDeterminedNilType = isTypeCheckErrorAnd isNotDeterminedNilType
+isTypeCheckErrorAndInvalidRecTypeDeclaration :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndInvalidRecTypeDeclaration = isTypeCheckErrorAnd isInvalidRecTypeDeclaration
+isTypeCheckErrorAndMultiDeclaredName :: SemantAnalysisError -> Bool
+isTypeCheckErrorAndMultiDeclaredName = isTypeCheckErrorAnd isMultiDeclaredName
+
+
+
+isTranslateErrorAnd :: (TranslateError -> Bool) -> SemantAnalysisError -> Bool
+isTranslateErrorAnd p (TranslateError e) = p e
+isTranslateErrorAnd _ _ = False
+
+
+isTranslateErrorAndBreakOutsideLoop :: SemantAnalysisError -> Bool
+isTranslateErrorAndBreakOutsideLoop = isTranslateErrorAnd isBreakOutsideLoop

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -5,7 +5,7 @@ import RIO
 
 import Unique
 
-import Tiger.Semant
+import Tiger.Semant.TypeCheck
 
 
 fetchTwoLabel :: (Label, Label)

--- a/test/Tiger/IntegrationSpec.hs
+++ b/test/Tiger/IntegrationSpec.hs
@@ -141,7 +141,8 @@ translateTest file = do
   bs <- liftIO $ B.readFile file
   e <- liftEither . mapLeft ParseError $ runP parser file bs
   liftEither . mapLeft (TranslateError . unLoc) . leaveEff . runTranslateEffWithNewLevel $ do
-    insertInitVEnv
+    insertInitVAEnv
+    insertInitVTEnv
     translateExp $ markEscape e
 
 runErrorTranslateTest :: FilePath -> (TranslateError -> IO ()) -> IO ()

--- a/test/Tiger/IntegrationSpec.hs
+++ b/test/Tiger/IntegrationSpec.hs
@@ -16,6 +16,7 @@ import           Tiger.Parser
 import           Tiger.Semant
 import           Tiger.Semant.Exp
 import           Tiger.Semant.MarkEscape
+import           Tiger.Semant.TypeCheck
 import           Tiger.Semant.Types
 
 

--- a/test/Tiger/IntegrationSpec.hs
+++ b/test/Tiger/IntegrationSpec.hs
@@ -27,94 +27,94 @@ spec = integrationSpec
 integrationSpec :: Spec
 integrationSpec = describe "integration test for translate" $ do
   it "then and else type differ" $
-    runErrorTranslateTest (testcase "test09.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test09.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
-  it "body of while is not unit" $
-    runErrorTranslateTest (testcase "test10.tig") (`shouldSatisfy` isExpectedUnitType)
+  it "body of while isTypeCheckErrorAnd not unit" $
+    runErrorTranslateTest (testcase "test10.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedUnitType)
 
   it "hi in for is not int" $
-    runErrorTranslateTest (testcase "test11.tig") (`shouldSatisfy` isExpectedIntType)
+    runErrorTranslateTest (testcase "test11.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedIntType)
 
   it "incompatible comparison: lt" $
-    runErrorTranslateTest (testcase "test13.tig") (`shouldSatisfy` isExpectedIntType)
+    runErrorTranslateTest (testcase "test13.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedIntType)
 
   it "incompatible comparison: eq" $
-    runErrorTranslateTest (testcase "test14.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test14.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
   it "if-then returns non unit" $
-    runErrorTranslateTest (testcase "test15.tig") (`shouldSatisfy` isExpectedUnitType)
+    runErrorTranslateTest (testcase "test15.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedUnitType)
 
   it "invalid recursive type" $
-    runErrorTranslateTest (testcase "test16.tig") (`shouldSatisfy` isInvalidRecTypeDeclaration)
+    runErrorTranslateTest (testcase "test16.tig") (`shouldSatisfy` isTypeCheckErrorAndInvalidRecTypeDeclaration)
 
   it "invalid recursive type: interrupted" $
-    runErrorTranslateTest (testcase "test17.tig") (`shouldSatisfy` isUnknownType)
+    runErrorTranslateTest (testcase "test17.tig") (`shouldSatisfy` isTypeCheckErrorAndUnknownType)
 
   it "invalid recursive function: interrupted" $
-    runErrorTranslateTest (testcase "test18.tig") (`shouldSatisfy` isUndefinedVariable)
+    runErrorTranslateTest (testcase "test18.tig") (`shouldSatisfy` isTypeCheckErrorAndUndefinedVariable)
 
   it "undefined variable" $
-    runErrorTranslateTest (testcase "test19.tig") (`shouldSatisfy` isUndefinedVariable)
+    runErrorTranslateTest (testcase "test19.tig") (`shouldSatisfy` isTypeCheckErrorAndUndefinedVariable)
 
   it "undefined variable" $
-    runErrorTranslateTest (testcase "test20.tig") (`shouldSatisfy` isUndefinedVariable)
+    runErrorTranslateTest (testcase "test20.tig") (`shouldSatisfy` isTypeCheckErrorAndUndefinedVariable)
 
   it "procedure returns value" $
-    runErrorTranslateTest (testcase "test21.tig") (`shouldSatisfy` isExpectedIntType)
+    runErrorTranslateTest (testcase "test21.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedIntType)
 
   it "missing field in record" $
-    runErrorTranslateTest (testcase "test22.tig") (`shouldSatisfy` isMissingRecordField)
+    runErrorTranslateTest (testcase "test22.tig") (`shouldSatisfy` isTypeCheckErrorAndMissingRecordField)
 
   it "type mismatch" $
-    runErrorTranslateTest (testcase "test23.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test23.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
   it "not array variable" $
-    runErrorTranslateTest (testcase "test24.tig") (`shouldSatisfy` isExpectedArrayType)
+    runErrorTranslateTest (testcase "test24.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedArrayType)
 
   it "not record variable" $
-    runErrorTranslateTest (testcase "test25.tig") (`shouldSatisfy` isExpectedRecordType)
+    runErrorTranslateTest (testcase "test25.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedRecordType)
 
   it "integer required" $
-    runErrorTranslateTest (testcase "test26.tig") (`shouldSatisfy` isExpectedIntType)
+    runErrorTranslateTest (testcase "test26.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedIntType)
 
   it "different record type" $
-    runErrorTranslateTest (testcase "test28.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test28.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
   it "different array type" $
-    runErrorTranslateTest (testcase "test29.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test29.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
   it "init type differs from declared" $
-    runErrorTranslateTest (testcase "test31.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test31.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
   it "init type of array differed from declared" $
-    runErrorTranslateTest (testcase "test32.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test32.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
   it "unknown type" $
-    runErrorTranslateTest (testcase "test33.tig") (`shouldSatisfy` isUnknownType)
+    runErrorTranslateTest (testcase "test33.tig") (`shouldSatisfy` isTypeCheckErrorAndUnknownType)
 
   it "type mismatched in function call" $
-    runErrorTranslateTest (testcase "test34.tig") (`shouldSatisfy` isExpectedTypes)
+    runErrorTranslateTest (testcase "test34.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedTypes)
 
   it "less argument" $
-    runErrorTranslateTest (testcase "test35.tig") (`shouldSatisfy` isExpectedTypes)
+    runErrorTranslateTest (testcase "test35.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedTypes)
 
   it "more argument" $
-    runErrorTranslateTest (testcase "test36.tig") (`shouldSatisfy` isExpectedTypes)
+    runErrorTranslateTest (testcase "test36.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedTypes)
 
   it "type already declared" $
-    runErrorTranslateTest (testcase "test38.tig") (`shouldSatisfy` isMultiDeclaredName)
+    runErrorTranslateTest (testcase "test38.tig") (`shouldSatisfy` isTypeCheckErrorAndMultiDeclaredName)
 
   it "function already declared" $
-    runErrorTranslateTest (testcase "test39.tig") (`shouldSatisfy` isMultiDeclaredName)
+    runErrorTranslateTest (testcase "test39.tig") (`shouldSatisfy` isTypeCheckErrorAndMultiDeclaredName)
 
   it "procedure returns value" $
-    runErrorTranslateTest (testcase "test40.tig") (`shouldSatisfy` isExpectedType)
+    runErrorTranslateTest (testcase "test40.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedType)
 
   it "type mismatch in addition" $
-    runErrorTranslateTest (testcase "test43.tig") (`shouldSatisfy` isExpectedIntType)
+    runErrorTranslateTest (testcase "test43.tig") (`shouldSatisfy` isTypeCheckErrorAndExpectedIntType)
 
   it "mismatch initialization by nil" $
-    runErrorTranslateTest (testcase "test45.tig") (`shouldSatisfy` isNotDeterminedNilType)
+    runErrorTranslateTest (testcase "test45.tig") (`shouldSatisfy` isTypeCheckErrorAndNotDeterminedNilType)
 
   it "valid test cases" $ do
     let testcases = (++) <$> (("test/Tiger/samples/test" ++) <$> validTestCases) <*> [".tig"]
@@ -135,19 +135,19 @@ integrationSpec = describe "integration test for translate" $ do
     validTestCases = (\(d :: Integer) -> if d < 10 then '0' : show d else show d) <$> concat [[1..8], [12], [27], [30], [37], [41..42], [44], [46..48]]
 
 
-data Error = ParseError String | TranslateError TranslateError deriving Show
+data Error = ParseError String | SemantAnalysisError SemantAnalysisError deriving Show
 translateTest :: FilePath -> ExceptT Error IO ((Exp, Type), [ProgramFragment FrameMock])
 translateTest file = do
   bs <- liftIO $ B.readFile file
   e <- liftEither . mapLeft ParseError $ runP parser file bs
-  liftEither . mapLeft (TranslateError . unLoc) . leaveEff . runTranslateEffWithNewLevel $ do
+  liftEither . mapLeft (SemantAnalysisError . unLoc) . leaveEff . runTranslateEffWithNewLevel $ do
     insertInitVAEnv
     insertInitVTEnv
     translateExp $ markEscape e
 
-runErrorTranslateTest :: FilePath -> (TranslateError -> IO ()) -> IO ()
+runErrorTranslateTest :: FilePath -> (SemantAnalysisError -> IO ()) -> IO ()
 runErrorTranslateTest file assert =
   runExceptT (translateTest file) >>= \case
     Right _ -> pure ()
     Left (ParseError msg) -> expectationFailure $ "parse error: " ++ msg
-    Left (TranslateError e) -> assert e
+    Left (SemantAnalysisError e) -> assert e

--- a/test/Tiger/Semant/TypeCheckSpec.hs
+++ b/test/Tiger/Semant/TypeCheckSpec.hs
@@ -71,7 +71,7 @@ typeCheckArrayIndexSpec = describe "type check array index test" $ do
 runEff :: Eff '[
         ("typeEnv" >: State TEnv)
       , ("id" >: UniqueEff)
-      , ("translateError" >: EitherEff (RealLocated TranslateError))
+      , ("typeCheckError" >: EitherEff (RealLocated TypeCheckError))
       ] a
-  -> Either (RealLocated TranslateError) a
-runEff = leaveEff . runEitherEff @"translateError" . runUniqueEff @"id" . evalTEnvEff initTEnv
+  -> Either (RealLocated TypeCheckError) a
+runEff = leaveEff . runEitherEff @"typeCheckError" . runUniqueEff @"id" . evalTEnvEff initTEnv

--- a/test/Tiger/Semant/TypeCheckSpec.hs
+++ b/test/Tiger/Semant/TypeCheckSpec.hs
@@ -1,0 +1,58 @@
+module Tiger.Semant.TypeCheckSpec (spec) where
+
+import           Control.Monad.Trans.Cont
+import           Data.Extensible
+import           RIO
+import qualified RIO.List as List
+import qualified RIO.List.Partial as Partial
+import qualified RIO.Map as Map
+import           Test.Hspec
+
+import qualified Frame as F
+import           FrameMock
+import qualified IR
+import           SrcLoc
+import           TestUtils
+import           Unique
+
+import           Tiger.Semant
+import           Tiger.Semant.BreakPoint
+import           Tiger.Semant.Env
+import           Tiger.Semant.Exp
+import           Tiger.Semant.Level
+import           Tiger.Semant.Translate
+import           Tiger.Semant.TypeCheck
+import           Tiger.Semant.Types
+import qualified Tiger.LSyntax as T (valueToLValue)
+import qualified Tiger.Syntax as T
+
+
+spec :: Spec
+spec = describe "hoge" $
+  it "a[0]" $ do
+    let ast = T.valueToLValue $ T.ArrayIndex (T.Id "a") (T.Int 0)
+        result = runEff $ do
+          id <- getUniqueEff #id
+          let arrayTy = TArray $ #range @= TInt <: #id @= id <: nil
+          insertType "a" arrayTy
+          evalContT (typeCheckValue ast) >>= \case
+            Done _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "1"
+            Next (Exp _) _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "2"
+            Next (Value _) k -> k arrayTy >>= \case
+                Done ty -> throwEff #translateError . dummyRealLocated $ NotImplemented $ "3: " ++ show ty
+                Next (Value _) _ -> throwEff #translateError . dummyRealLocated $ NotImplemented $ "4"
+                Next (Exp _) k -> k TInt >>= \case
+                    Done ty -> pure ty
+                    _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "5"
+    case result of
+      Left (L _ e) -> expectationFailure $ show e
+      Right ty -> do
+        ty `shouldBe` TInt
+
+runEff :: Eff '[
+        ("typeEnv" >: State TEnv)
+      , ("id" >: UniqueEff)
+      , ("translateError" >: EitherEff (RealLocated TranslateError))
+      ] a
+  -> Either (RealLocated TranslateError) a
+runEff = leaveEff . runEitherEff @"translateError" . runUniqueEff @"id" . evalTEnvEff initTEnv

--- a/test/Tiger/Semant/TypeCheckSpec.hs
+++ b/test/Tiger/Semant/TypeCheckSpec.hs
@@ -23,31 +23,50 @@ import           Tiger.Semant.Level
 import           Tiger.Semant.Translate
 import           Tiger.Semant.TypeCheck
 import           Tiger.Semant.Types
-import qualified Tiger.LSyntax as T (valueToLValue)
+import qualified Tiger.LSyntax as T (valueToLValue, expToLExp)
 import qualified Tiger.Syntax as T
 
 
 spec :: Spec
-spec = describe "hoge" $
-  it "a[0]" $ do
-    let ast = T.valueToLValue $ T.ArrayIndex (T.Id "a") (T.Int 0)
-        result = runEff $ do
+spec = typeCheckArrayIndexSpec
+
+typeCheckArrayIndexSpec :: Spec
+typeCheckArrayIndexSpec = describe "type check array index test" $ do
+  it "var a: array int; a[0]" $ do
+    let result = runEff $ do
           id <- getUniqueEff #id
           let arrayTy = TArray $ #range @= TInt <: #id @= id <: nil
           insertType "a" arrayTy
-          evalContT (typeCheckValue ast) >>= \case
-            Done _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "1"
-            Next (Exp _) _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "2"
-            Next (Value _) k -> k arrayTy >>= \case
-                Done ty -> throwEff #translateError . dummyRealLocated $ NotImplemented $ "3: " ++ show ty
-                Next (Value _) _ -> throwEff #translateError . dummyRealLocated $ NotImplemented $ "4"
-                Next (Exp _) k -> k TInt >>= \case
-                    Done ty -> pure ty
-                    _ -> throwEff #translateError . dummyRealLocated $ NotImplemented "5"
+          (_, cont) <- typeCheckArrayIndex (dummyRealLocated (T.valueToLValue $ T.Id "a", T.expToLExp $ T.Int 0))
+          (_, cont) <- cont arrayTy
+          cont TInt
     case result of
       Left (L _ e) -> expectationFailure $ show e
-      Right ty -> do
-        ty `shouldBe` TInt
+      Right ty -> ty `shouldBe` TInt
+
+  it "var a: array int; a['hoge']" $ do
+    let result = runEff $ do
+          id <- getUniqueEff #id
+          let arrayTy = TArray $ #range @= TInt <: #id @= id <: nil
+          insertType "a" arrayTy
+          (_, cont) <- typeCheckArrayIndex (dummyRealLocated (T.valueToLValue $ T.Id "a", T.expToLExp $ T.String "hoge"))
+          (_, cont) <- cont arrayTy
+          cont TString
+    case result of
+      Right ty -> expectationFailure $ "should return ExpectedIntType, but got " ++ show ty
+      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+
+  it "var x: int; a[0]" $ do
+    let result = runEff $ do
+          insertType "a" TInt
+          (_, cont) <- typeCheckArrayIndex (dummyRealLocated (T.valueToLValue $ T.Id "a", T.expToLExp $ T.Int 0))
+          (_, cont) <- cont TInt
+          cont TInt
+    case result of
+      Right ty -> expectationFailure $ "should return ExpectedArrayType, but got " ++ show ty
+      Left (L _ e) -> e `shouldSatisfy` isExpectedArrayType
+
+
 
 runEff :: Eff '[
         ("typeEnv" >: State TEnv)

--- a/test/Tiger/SemantSpec.hs
+++ b/test/Tiger/SemantSpec.hs
@@ -4,7 +4,6 @@ import           Data.Extensible
 import           RIO
 import qualified RIO.List as List
 import qualified RIO.List.Partial as Partial
-import qualified RIO.Map as Map
 import           Test.Hspec
 
 import qualified Frame as F
@@ -20,6 +19,7 @@ import           Tiger.Semant.Env
 import           Tiger.Semant.Exp
 import           Tiger.Semant.Level
 import           Tiger.Semant.Translate
+import           Tiger.Semant.TypeCheck
 import           Tiger.Semant.Types
 import qualified Tiger.LSyntax as T (expToLExp)
 import qualified Tiger.Syntax as T

--- a/test/Tiger/SemantSpec.hs
+++ b/test/Tiger/SemantSpec.hs
@@ -153,7 +153,7 @@ translateVariableSpec = describe "translate variable test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return undefined variable error: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUndefinedVariable
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUndefinedVariable
 
   it "variable referes function" $ do
     let ast = T.expToLExp $ T.Var (T.Id "x")
@@ -163,7 +163,7 @@ translateVariableSpec = describe "translate variable test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return undefined variable error: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedVariable
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedVariable
 
 
 translateRecordFieldSpec :: Spec
@@ -216,7 +216,7 @@ translateRecordFieldSpec = describe "translate record field test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedRecordType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedRecordType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedRecordType
 
   it "missing record field" $ do
     let ast = T.expToLExp $ T.Var (T.RecField (T.Id "object") "z")
@@ -227,7 +227,7 @@ translateRecordFieldSpec = describe "translate record field test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return MissingRecordField: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isMissingRecordField
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndMissingRecordField
 
 
 translateArrayIndexSpec :: Spec
@@ -297,7 +297,7 @@ translateArrayIndexSpec = describe "translate array index test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType" ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
   it "array type expected" $ do
     let ast = T.expToLExp $ T.Var (T.ArrayIndex (T.Id "x") (T.Int 0))
@@ -306,7 +306,7 @@ translateArrayIndexSpec = describe "translate array index test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedArrayType" ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedArrayType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedArrayType
 
 translateBinOpSpec :: Spec
 translateBinOpSpec = describe "translate binop test" $ do
@@ -326,7 +326,7 @@ translateBinOpSpec = describe "translate binop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
   it "x + x (array)" $ do
     let ast = T.expToLExp $ T.Op (T.Var (T.Id "x")) T.Plus (T.Var (T.Id "x"))
@@ -337,7 +337,7 @@ translateBinOpSpec = describe "translate binop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
   it "x == x (array)" $ do
     let ast = T.expToLExp $ T.Op (T.Var (T.Id "x")) T.Eq (T.Var (T.Id "x"))
@@ -360,7 +360,7 @@ translateBinOpSpec = describe "translate binop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return NotdeterminedNilType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isNotDeterminedNilType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndNotDeterminedNilType
 
   it "nil == x (record)" $ do
     let ast = T.expToLExp $ T.Op T.Nil T.Eq (T.Var (T.Id "x"))
@@ -419,7 +419,7 @@ translateBinOpSpec = describe "translate binop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedType
 
   it "0 + (0 == 0)" $ do
     let ast = T.expToLExp $ T.Op (T.Int 0) T.Plus (T.Op (T.Int 0) T.Eq (T.Int 0))
@@ -456,7 +456,7 @@ translateBinOpSpec = describe "translate binop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedExpression: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedExpression
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedExpression
 
   it "'hoge' < 'hoge'" $ do
     let ast = T.expToLExp $ T.Op (T.String "hoge") T.Lt (T.String "hoge")
@@ -464,7 +464,7 @@ translateBinOpSpec = describe "translate binop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
 
 translateIfElseSpec :: Spec
@@ -557,7 +557,7 @@ translateIfElseSpec = describe "translate if-else test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedTypeInt: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
 
 translateIfNoElseSpec :: Spec
@@ -615,7 +615,7 @@ translateIfNoElseSpec = describe "translate if-no-else test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedTypeInt: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
   it "if 0 then 0" $ do
     let ast = T.expToLExp $ T.If (T.Int 0) (T.Int 0) Nothing
@@ -624,7 +624,7 @@ translateIfNoElseSpec = describe "translate if-no-else test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedTypeInt: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedUnitType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedUnitType
 
 
 translateRecordCreationSpec :: Spec
@@ -733,7 +733,7 @@ translateRecordCreationSpec = describe "translate record creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return MissingRecordFieldInConstruction: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isMissingRecordFieldInConstruction
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndMissingRecordFieldInConstruction
 
   it "type record = {}; record {x = 1}" $ do
     let ast = T.expToLExp $ T.RecordCreate "record" [T.FieldAssign "x" (T.Int 1)]
@@ -744,7 +744,7 @@ translateRecordCreationSpec = describe "translate record creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExtraRecordFieldInConstruction: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExtraRecordFieldInConstruction
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExtraRecordFieldInConstruction
 
   it "type record = {x: int}; record {y = 'hoge'}" $ do
     let ast = T.expToLExp $ T.RecordCreate "record" [T.FieldAssign "y" (T.String "hoge")]
@@ -755,7 +755,7 @@ translateRecordCreationSpec = describe "translate record creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return MissingRecordFieldInConstruction: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isMissingRecordFieldInConstruction
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndMissingRecordFieldInConstruction
 
   it "type record = {x: int}; record {x = 'hoge'}" $ do
     let ast = T.expToLExp $ T.RecordCreate "record" [T.FieldAssign "x" (T.String "hoge")]
@@ -766,7 +766,7 @@ translateRecordCreationSpec = describe "translate record creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedTypeForRecordField: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedTypeForRecordField
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedTypeForRecordField
 
   it "type myint = int; myint {}" $ do
     let ast = T.expToLExp $ T.RecordCreate "myint" []
@@ -775,7 +775,7 @@ translateRecordCreationSpec = describe "translate record creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedRecordType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedRecordType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedRecordType
 
 
 translateArrayCreationSpec :: Spec
@@ -828,7 +828,7 @@ translateArrayCreationSpec = describe "translate array creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedArrayType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedArrayType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedArrayType
 
   it "type array = array of int; array [0] of 'hoge'" $ do
     let ast = T.expToLExp $ T.ArrayCreate "array" (T.Int 0) (T.String "hoge")
@@ -839,7 +839,7 @@ translateArrayCreationSpec = describe "translate array creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedType
 
   it "type array = array of int; array ['hoge'] of 0" $ do
     let ast = T.expToLExp $ T.ArrayCreate "array" (T.String "hoge") (T.Int 0)
@@ -850,7 +850,7 @@ translateArrayCreationSpec = describe "translate array creation test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
 
 translateWhileLoopSpec :: Spec
@@ -892,7 +892,7 @@ translateWhileLoopSpec = describe "translate while loop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
   it "while 0 == 0 do 0" $ do
     let ast = T.expToLExp $ T.While (T.Op (T.Int 0) T.Eq (T.Int 0)) (T.Int 0)
@@ -900,7 +900,7 @@ translateWhileLoopSpec = describe "translate while loop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedUnitType:" ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedUnitType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedUnitType
 
 
 translateForLoopSpec :: Spec
@@ -941,7 +941,7 @@ translateForLoopSpec = describe "translate for loop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedUnitType:" ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedUnitType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedUnitType
 
   it "for i := 'hoge' to 2 do y := 3" $ do
     let ast = T.expToLExp $ T.For "i" False (T.String "hoge") (T.Int 2) (T.Assign (T.Id "x") (T.Int 3))
@@ -950,7 +950,7 @@ translateForLoopSpec = describe "translate for loop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType"
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
   it "for i := 1 to 'hoge' do x := 3" $ do
     let ast = T.expToLExp $ T.For "i" False (T.Int 1) (T.String "hoge") (T.Assign (T.Id "x") (T.Int 3))
@@ -959,7 +959,7 @@ translateForLoopSpec = describe "translate for loop test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedIntType"
-      Left (L _ e) -> e `shouldSatisfy` isExpectedIntType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedIntType
 
 
 translateBreakSpec :: Spec
@@ -1009,7 +1009,7 @@ translateBreakSpec = describe "translate break test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return BreakOutsideLoop: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isBreakOutsideLoop
+      Left (L _ e) -> e `shouldSatisfy` isTranslateErrorAndBreakOutsideLoop
 
   it "(for i := 1 to 3 do x := 2, break)" $ do
     let ast = T.expToLExp $ T.Seq [T.For "i" False (T.Int 1) (T.Int 2) (T.Assign (T.Id "x") (T.Int 3)), T.Break]
@@ -1018,7 +1018,7 @@ translateBreakSpec = describe "translate break test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return BreakOutsideLoop: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isBreakOutsideLoop
+      Left (L _ e) -> e `shouldSatisfy` isTranslateErrorAndBreakOutsideLoop
 
 
 translateFunApplySpec :: Spec
@@ -1083,7 +1083,7 @@ translateFunApplySpec = describe "translate fun application test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedTypes: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedTypes
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedTypes
 
   it "f: () -> (); f(0)" $ do
     let ast = T.expToLExp $ T.FunApply "f" [T.Int 0]
@@ -1094,7 +1094,7 @@ translateFunApplySpec = describe "translate fun application test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedTypes: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedTypes
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedTypes
 
   it "f: int -> (); f()" $ do
     let ast = T.expToLExp $ T.FunApply "f" []
@@ -1105,7 +1105,7 @@ translateFunApplySpec = describe "translate fun application test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedTypes: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedTypes
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedTypes
 
   it "var f := (); f()" $ do
     let ast = T.expToLExp $ T.FunApply "f" []
@@ -1114,7 +1114,7 @@ translateFunApplySpec = describe "translate fun application test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedFunction: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedFunction
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedFunction
 
 
 translateAssignSpec :: Spec
@@ -1155,7 +1155,7 @@ translateAssignSpec = describe "translate assgin test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedType
 
 
 translateSeqSpec :: Spec
@@ -1658,7 +1658,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return UnknownType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUnknownType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUnknownType
 
   it "let x := let y := 0 in y in y" $ do
     let ast = T.expToLExp $ T.Let [T.VarDec "x" False Nothing (T.Let [T.VarDec "y" False Nothing (T.Int 0)] (T.Var (T.Id "y")))] (T.Var (T.Id "y"))
@@ -1666,7 +1666,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return UndefinedVariable: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUndefinedVariable
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUndefinedVariable
 
   it "let type a = b; type b = c; type c = a in 0" $ do
     let ast = T.expToLExp $ T.Let [T.TypeDec "a" (T.TypeId "b"), T.TypeDec "b" (T.TypeId "c"), T.TypeDec "c" (T.TypeId "a")] (T.Int 0)
@@ -1674,7 +1674,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return InvalidRecTypeDeclaration: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isInvalidRecTypeDeclaration
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndInvalidRecTypeDeclaration
 
   it "type a = {a: b}; var x = 0; type b = {b: a} in x" $ do
     let ast = T.expToLExp $ T.Let [T.TypeDec "a" (T.RecordType [T.Field "a" False "b"]), T.VarDec "x" False Nothing (T.Int 0), T.TypeDec "b" (T.RecordType [T.Field "b" False "a"])] (T.Var (T.Id "x"))
@@ -1682,7 +1682,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return UnknownType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUnknownType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUnknownType
 
   it "let function f() = g(); var x := 0; function g() = f() in f()" $ do
     let ast = T.expToLExp $ T.Let [T.FunDec "f" [] Nothing (T.FunApply "g" []), T.VarDec "x" False Nothing (T.Int 0), T.FunDec "g" [] Nothing (T.FunApply "f" [])] (T.FunApply "g" [])
@@ -1690,7 +1690,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return UndefinedVariale: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUndefinedVariable
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUndefinedVariable
 
   it "let var x: int = 'hoge' in x" $ do
     let ast = T.expToLExp $ T.Let [T.VarDec "x" False (Just "int") (T.String "hoge")] (T.Var (T.Id "x"))
@@ -1698,7 +1698,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return ExpectedType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isExpectedType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndExpectedType
 
   it "let function f(x: hoge): int = 0 in 0" $ do
     let ast = T.expToLExp $ T.Let [T.FunDec "f" [T.Field "x" False "hoge"] (Just "int") (T.Int 0)] (T.Int 0)
@@ -1706,7 +1706,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return UnknownType: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUnknownType
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUnknownType
 
   it "let function f(): int = 0; function f(): int = 0 in 0" $ do
     let ast = T.expToLExp $ T.Let [T.FunDec "f" [] (Just "int") (T.Int 0), T.FunDec "f" [] (Just "int") (T.Int 0)] (T.Int 0)
@@ -1714,7 +1714,7 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return MultiDeclaredName: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isMultiDeclaredName
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndMultiDeclaredName
 
   it "let type a = int; type a = string in 0" $ do
     let ast = T.expToLExp $ T.Let [T.TypeDec "a" (T.TypeId "int"), T.TypeDec "a" (T.TypeId "int")] (T.Int 0)
@@ -1722,21 +1722,21 @@ translateLetSpec = describe "translate let test" $ do
           translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return MultiDeclaredName: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isMultiDeclaredName
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndMultiDeclaredName
 
   it "let function f(x: int): int = x; function g(): int = x in g()" $ do
     let ast = T.expToLExp $ T.Let [T.FunDec "f" [T.Field "x" False "int"] (Just "int") (T.Var (T.Id "x")), T.FunDec "g" [] (Just "int") (T.Var (T.Id "x"))] (T.FunApply "g" [])
         result = runEff $ translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return UndefinedVariable: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUndefinedVariable
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUndefinedVariable
 
   it "let x = let function f(x: int): int = x in f(1) in f(2)" $ do
     let ast = T.expToLExp $ T.Let [T.VarDec "x" False (Just "int") (T.Let [T.FunDec "f" [T.Field "x" False "int"] (Just "int") (T.Var (T.Id "x"))] (T.FunApply "f" [T.Int 1]))] (T.FunApply "f" [T.Int 2])
         result = runEff $ translateExp ast
     case result of
       Right ret -> expectationFailure $ "should return UndefinedVariable: " ++ show ret
-      Left (L _ e) -> e `shouldSatisfy` isUndefinedVariable
+      Left (L _ e) -> e `shouldSatisfy` isTypeCheckErrorAndUndefinedVariable
 
 runEff :: Eff '[
         ("typeEnv" >: State TEnv)
@@ -1748,9 +1748,10 @@ runEff :: Eff '[
       , ("temp" >: UniqueEff)
       , ("label" >: UniqueEff)
       , ("id" >: UniqueEff)
+      , ("typeCheckError" >: EitherEff (RealLocated TypeCheckError))
       , ("translateError" >: EitherEff (RealLocated TranslateError))
       ] a
-  -> Either (RealLocated TranslateError) (a, [F.ProgramFragment FrameMock])
+  -> Either (RealLocated SemantAnalysisError) (a, [F.ProgramFragment FrameMock])
 runEff = leaveEff . runTranslateEffWithNewLevel
 
 allocateLocalVariableAndInsertType :: (


### PR DESCRIPTION
ref. #2 

## What I did
- introduced Coroutine Type to achieve separation of concern in semantic analysis
- separate type checking from semantic analysis
- implement a few tests for type checking

## Concern
Are they easy to understand?

## Detail
Coroutine Type is as follows:
```haskell
type family Coroutine (xs :: [*]) (m :: * -> *) (r :: *) where
  Coroutine '[] m r = m r
  Coroutine ((a, b) ': xs) m r = m (a, b -> Coroutine xs m r)

yield :: forall xs m a b r. Monad m => a -> (b -> Coroutine xs m r) -> Coroutine ((a, b) ': xs) m r
yield value cont = pure (value, cont)
```
Eg.) 
```haskell
Coroutine '[(Int, String), (String, Int)] IO String 
= IO (Int, String -> IO (String, Int -> IO String))
```
This expresses that I will return Int, and give me a String, then return String, and give me a Int, then return String in IO monad.
It's like a coroutine.
The coroutine enables us to separate side-effects and achieve the separation of concern.